### PR TITLE
Integrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem 'peek-host', github: "kailan/peek-host"
 gem 'peek-redis'
 gem 'peek-mongo'
 
+# Integrations
+gem 'slack-ruby-client', '~> 0.9'
+
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     fast-stemmer (1.0.2)
     ffi (1.9.18)
     flex-slider-rails (2.6.3)
@@ -126,6 +128,7 @@ GEM
       railties (>= 3.2, < 5.2)
     formatador (0.2.5)
     git (1.3.0)
+    gli (2.16.1)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     groupify (0.8.0)
@@ -163,6 +166,7 @@ GEM
       multi_json (>= 1.2)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
+    json (2.1.0)
     jwt (1.5.6)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
@@ -344,6 +348,14 @@ GEM
       rails (~> 5.0, >= 5.0.1)
     sexp_processor (4.10.0)
     shellany (0.0.1)
+    slack-ruby-client (0.9.1)
+      activesupport
+      faraday (>= 0.9)
+      faraday_middleware
+      gli
+      hashie
+      json
+      websocket-driver
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -429,6 +441,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   scram (~> 0.1.1)
+  slack-ruby-client (~> 0.9)
   spring
   spring-watcher-listen (~> 2.0.0)
   tinymce-rails

--- a/app/controllers/admin/escalation_requests_controller.rb
+++ b/app/controllers/admin/escalation_requests_controller.rb
@@ -32,11 +32,13 @@ module Admin
       @escalation_request.save
 
       if @escalation_request.errors.empty?
-          flash[:notice] = 'Escalation request successfully created.'
-          redirect_to url_for(@escalatable) rescue redirect_to root_path
+        type_name = @escalation_request.escalatable.class.to_s.downcase
+        notify_integrations "*#{current_user.name}* wants to escalate their #{type_name}: #{url_for(@escalatable)}\n> #{@escalation_request.note}"
+        flash[:notice] = 'Escalation request successfully created.'
+        redirect_to url_for(@escalatable) rescue redirect_to root_path
       else
-          flash.now[:alert] = @escalation_request.errors.full_messages.first
-          render action: 'new'
+        flash.now[:alert] = @escalation_request.errors.full_messages.first
+        render action: 'new'
       end
     end
 

--- a/app/controllers/admin/escalation_requests_controller.rb
+++ b/app/controllers/admin/escalation_requests_controller.rb
@@ -6,6 +6,7 @@ module Admin
     def approve
       authorize @escalation_request, :approve
       @escalation_request.approve!(current_user)
+      notify_integrations "*#{current_user.name}* approved an escalation request from *#{@escalation_request.requester.name}* for #{url_for(@escalation_request.escalatable)}"      
       flash[:notice] = 'Escalation request successfully approved.'
       redirect_to admin_escalation_requests_path
     end
@@ -13,6 +14,7 @@ module Admin
     def deny
       authorize @escalation_request, :deny
       @escalation_request.deny!(current_user)
+      notify_integrations "*#{current_user.name}* denied an escalation request from *#{@escalation_request.requester.name}* for #{url_for(@escalation_request.escalatable)}"      
       flash[:notice] = 'Escalation request successfully denied.'
       redirect_to admin_escalation_requests_path
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def notify_integrations(message)
+    Integration.each {|i| i.create_provider.notify(message)}
+  end
+
   rescue_from ActionController::RoutingError, :with => :not_found
   rescue_from Mongoid::Errors::DocumentNotFound, :with => :not_found
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,6 +2,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
       @user = User.from_omniauth(request.env['omniauth.auth'])
 
+      if @user.sign_in_count < 1
+        if @user.staff?
+          notify_integrations "*#{@user.name}* (#{@user.email}) just signed in with Google. User count is at #{User.count}."
+        end
+      end
+
       if @user.persisted?
         flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Google'
         sign_in_and_redirect @user, event: :authentication

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,0 +1,28 @@
+require_dependencies 'integration/*'
+
+class Integration
+  include Mongoid::Document
+
+  def self.providers
+    [Syosset::Integrations::Slack]
+  end
+
+  field :provider_name, type: String
+  validates :provider_name, presence: true
+
+  field :properties, type: Hash
+  validates_with IntegrationValidator
+
+  def provider=(provider_class)
+    provider_name = provider_class.name
+  end
+
+  def provider
+    provider_name.constantize
+  end
+
+  def create_provider
+    provider.send('new', properties)
+  end
+
+end

--- a/app/models/integration/integration_validator.rb
+++ b/app/models/integration/integration_validator.rb
@@ -1,0 +1,13 @@
+class IntegrationValidator < ActiveModel::Validator
+
+  def validate(record)
+    raise "Unable to validate a model that isn't an integration." unless record.is_a? Integration
+
+    begin
+      record.create_provider
+    rescue => error
+      record.errors[:integration] << error.message
+    end 
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,4 +59,9 @@ class User
       end
       user
   end
+
+  def staff?
+    super_admin || (/^[a-z]+\@syosset\.k12\.ny\.us$/ =~ email) == 0
+  end
+  
 end

--- a/config/initializers/load_integrations.rb
+++ b/config/initializers/load_integrations.rb
@@ -1,0 +1,1 @@
+Dir[Rails.root + 'lib/integrations/**/*.rb'].each {|file| require file}

--- a/lib/integrations/integration_provider.rb
+++ b/lib/integrations/integration_provider.rb
@@ -1,0 +1,15 @@
+module Syosset
+  module Integrations
+    module IntegrationProvider
+
+      def options
+        return Hash.new
+      end
+
+      def notify(message)
+        raise "not implemented!"
+      end
+
+    end
+  end
+end

--- a/lib/integrations/slack_provider.rb
+++ b/lib/integrations/slack_provider.rb
@@ -1,0 +1,25 @@
+module Syosset
+  module Integrations
+    class Slack
+      include IntegrationProvider
+
+      def initialize(opts = {})
+        unless opts.key? :token
+          raise "No Slack API token provided."
+        end
+
+        @client = ::Slack::Web::Client.new(opts)
+        @channel = opts[:channel] || '#general'
+      end
+
+      def options
+        {token: @client.token, channel: @channel}
+      end
+
+      def notify(message)
+        @client.chat_postMessage(channel: @channel, text: message, as_user: true)
+      end
+
+    end
+  end
+end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Integration, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This adds an integration API and a Slack integration.

Notifications are currently sent upon escalation request creation, escalation request acceptance/denial, and staff signup.

An admin UI for managing integrations still needs to be created, however this can be done later.
A slack integration can be created in the console by running `Integration.create(provider_name: "Syosset::Integrations::Slack", properties: {token: "xoxb-slack-token"})`